### PR TITLE
Fixes for SZ auto and Spack

### DIFF
--- a/include/sz_decompression_utils.hpp
+++ b/include/sz_decompression_utils.hpp
@@ -71,7 +71,7 @@ decode_regression_coefficients(const unsigned char *& compressed_pos, size_t reg
 	float * prev_reg_params = reg_params;
 	float * reg_params_pos = reg_params + RegCoeffNum3d;
 	const int * type_pos = (const int *) reg_type;
-	for(int i=0; i<reg_count; i++){
+	for(size_t i=0; i<reg_count; i++){
 		for(int j=0; j<RegCoeffNum3d; j++){
 			*reg_params_pos = recover(*prev_reg_params, reg_precisions[j], *(type_pos++), RegCoeffRadius, reg_unpredictable_data_pos);
 			prev_reg_params ++, reg_params_pos ++;
@@ -83,7 +83,7 @@ decode_regression_coefficients(const unsigned char *& compressed_pos, size_t reg
 
 template<typename T>
 float *
-decode_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t reg_count, int block_size, T precision, const sz_params &params){
+decode_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t reg_count, int , T , const sz_params &params){
     size_t reg_unpredictable_count = 0;
     read_variable_from_src(compressed_pos, reg_unpredictable_count);
     const float * reg_unpredictable_data_pos = (const float *) compressed_pos;
@@ -100,7 +100,7 @@ decode_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t 
     float * prev_reg_params = reg_params;
     float * reg_params_pos = reg_params + RegCoeffNum3d;
     const int * type_pos = (const int *) reg_type;
-    for(int i=0; i<reg_count; i++){
+    for(size_t i=0; i<reg_count; i++){
         for(int j=0; j<RegCoeffNum3d; j++){
             *reg_params_pos = recover(*prev_reg_params, reg_precisions[j], *(type_pos++), RegCoeffRadius, reg_unpredictable_data_pos);
             prev_reg_params ++, reg_params_pos ++;
@@ -111,7 +111,7 @@ decode_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t 
 }
 template<typename T>
 float *
-decode_poly_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t reg_count, int block_size, T precision, const sz_params &params){
+decode_poly_regression_coefficients_v2(const unsigned char *& compressed_pos, size_t reg_count, int /*block_size*/, T /*precision*/, const sz_params &params){
 	size_t reg_unpredictable_count = 0;
 	read_variable_from_src(compressed_pos, reg_unpredictable_count);
 	const float * reg_unpredictable_data_pos = (const float *) compressed_pos;
@@ -133,7 +133,7 @@ decode_poly_regression_coefficients_v2(const unsigned char *& compressed_pos, si
 	float * prev_reg_params = reg_params;
 	float * reg_params_pos = reg_params + RegPolyCoeffNum3d;
 	const int * type_pos = (const int *) reg_type;
-	for(int i=0; i<reg_count; i++){
+	for(size_t i=0; i<reg_count; i++){
 		for(int j=0; j<RegPolyCoeffNum3d; j++){
 			*reg_params_pos = recover(*prev_reg_params, reg_precisions_poly[j], *(type_pos++), RegCoeffRadius, reg_unpredictable_data_pos);
 			prev_reg_params ++, reg_params_pos ++;

--- a/include/sz_def.hpp
+++ b/include/sz_def.hpp
@@ -145,9 +145,9 @@ struct DSize_3d {
     size_t num_blocks;
     size_t dim0_offset;
     size_t dim1_offset;
-    int sample_nx;
-    int sample_ny;
-    int sample_nz;
+    size_t sample_nx;
+    size_t sample_ny;
+    size_t sample_nz;
     size_t sample_distance;
 
     DSize_3d(size_t r1, size_t r2, size_t r3, int bs) {

--- a/include/sz_optimize_quant_intervals.hpp
+++ b/include/sz_optimize_quant_intervals.hpp
@@ -2,6 +2,7 @@
 #define _sz_optimize_quant_intervals_hpp
 
 #include <vector>
+#include "sz_compression_utils.hpp"
 
 unsigned int
 static estimate_quantization_intervals(const std::vector<size_t>& intervals, size_t sample_count){
@@ -44,7 +45,7 @@ sample_rough_mean_3d(const T * data, size_t r1, size_t r2, size_t r3, size_t sam
 	size_t offset_count = 0;
 	size_t offset_count_2 = 0;
 	size_t mean_count = 0;
-	while(data_pos - data < len){
+	while(static_cast<size_t>(data_pos - data) < len){
 		mean += *data_pos;
 		mean_count ++;
 		data_pos += sample_distance;
@@ -84,7 +85,7 @@ optimize_quant_invl_3d(const T * data, size_t r1, size_t r2, size_t r3, double p
 	size_t pred_index = 0;
 	float pred_err = 0;
 	int radius = (QuantIntvMeanCapacity >> 1);
-	while(data_pos - data < len){
+	while(static_cast<size_t>(data_pos - data) < len){
 		pred_value = lorenzo_predict_3d(data_pos, r23, r3);
 		pred_err = fabs(pred_value - *data_pos);
 		if(pred_err < precision) freq_count ++;
@@ -100,7 +101,7 @@ optimize_quant_invl_3d(const T * data, size_t r1, size_t r2, size_t r3, double p
 		if(freq_index <= 0){
 			freq_intervals[0] ++;
 		}
-		else if(freq_index >= freq_intervals.size()){
+		else if(freq_index >= static_cast<ptrdiff_t>(freq_intervals.size())){
 			freq_intervals[freq_intervals.size() - 1] ++;
 		}
 		else{

--- a/include/sz_prediction.hpp
+++ b/include/sz_prediction.hpp
@@ -1,6 +1,8 @@
 #ifndef _sz_prediction_hpp
 #define _sz_prediction_hpp
 
+#include <cstddef>
+
 template<typename T>
 inline T
 regression_predict_3d(const float * reg_params_pos, int x, int y, int z){
@@ -19,26 +21,26 @@ regression_predict_3d_poly(const float * reg_params_pos, int x, int y, int z){
 
 template<typename T>
 inline T
-lorenzo_predict_1d(const T * data_pos, size_t dim0_offset){
+lorenzo_predict_1d(const T * data_pos, size_t){
 	return data_pos[-1];
 }
 
 template<typename T>
 inline T
-lorenzo_predict_1d_2layer(const T * data_pos, size_t dim0_offset){
+lorenzo_predict_1d_2layer(const T * data_pos, size_t ){
     return 2 * data_pos[-1] - data_pos[-2];
 }
 
 
 template<typename T>
 inline T
-lorenzo_predict_2d(const T * data_pos, size_t dim0_offset, size_t dim1_offset){
+lorenzo_predict_2d(const T * data_pos, size_t dim0_offset, size_t ){
 	return data_pos[-1] + data_pos[-dim0_offset] - data_pos[-1 - dim0_offset];
 }
 
 template<typename T>
 inline T
-lorenzo_predict_2d_2layer(const T * data_pos, size_t dim0_offset, size_t dim1_offset){
+lorenzo_predict_2d_2layer(const T * data_pos, size_t dim0_offset, size_t){
     return 2 * data_pos[-dim0_offset]
            - data_pos[-2 * dim0_offset]
            + 2 * data_pos[-1]

--- a/include/sz_regression_utils.hpp
+++ b/include/sz_regression_utils.hpp
@@ -2,9 +2,9 @@
 #define _sz_regression_utils_hpp
 
 #include "sz_utils.hpp"
-#include "sz_poly_regression_coeff_aux.hpp"
 #include "sz_def.hpp"
 #include <array>
+#include <vector>
 #include <iomanip>
 #include <algorithm>
 
@@ -32,28 +32,7 @@ void display_coef_aux(std::array<T, RegPolyCoeffNum3d * RegPolyCoeffNum3d> aux) 
 }
 
 //template<typename T>
-std::vector<std::array<float, RegPolyCoeffNum3d * RegPolyCoeffNum3d>> init_poly() {
-
-    float *data = COEFF_3D;
-    size_t num = sizeof(COEFF_3D) / sizeof(float);;
-
-    auto coef_aux_p = &data[0];
-    std::vector<std::array<float, RegPolyCoeffNum3d * RegPolyCoeffNum3d>> coef_aux_list = std::vector<std::array<float,
-            RegPolyCoeffNum3d * RegPolyCoeffNum3d>>(
-            (COEF_AUX_MAX_BLOCK + 1) * (COEF_AUX_MAX_BLOCK + 1) * (COEF_AUX_MAX_BLOCK + 1), {0});
-    while (coef_aux_p < &data[0] + num) {
-        std::array<size_t, 3> dims = {0};
-        for (auto &idx:dims) {
-            idx = *coef_aux_p++;
-        }
-        std::copy_n(coef_aux_p, RegPolyCoeffNum3d * RegPolyCoeffNum3d,
-                    coef_aux_list[get_coef_aux_list_idx(dims)].begin());
-        coef_aux_p += RegPolyCoeffNum3d * RegPolyCoeffNum3d;
-    }
-//    display_coef_aux(coef_aux_list[get_coef_aux_list_idx( std::array<size_t, 3>{6, 6, 6})]);
-    free(data);
-    return coef_aux_list;
-}
+std::vector<std::array<float, RegPolyCoeffNum3d * RegPolyCoeffNum3d>> init_poly(); 
 
 template<typename T>
 inline void

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,9 @@ add_library (sz_cpp
 	sz_decompression_utils.cpp
 	sz_decompress_3d.cpp
 	sz_huffman.cpp
-	sz_lossless.cpp)
+	sz_lossless.cpp
+  sz_regression_utils.cpp
+  )
 target_compile_features(sz_cpp
   PUBLIC
   cxx_std_14

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,10 +29,5 @@ install(TARGETS sz_cpp ${thirdparty_export} EXPORT szautoConfig
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(FILES 
-  ${PROJECT_SOURCE_DIR}/data/PolyRegressionCoefAux1D.f32
-  ${PROJECT_SOURCE_DIR}/data/PolyRegressionCoefAux2D.f32
-  ${PROJECT_SOURCE_DIR}/data/PolyRegressionCoefAux3D.f32
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/szauto)
 install(EXPORT szautoConfig NAMESPACE szauto:: DESTINATION ${CMAKE_INSTALL_DATADIR}/szauto/cmake)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/szauto)

--- a/src/sz_autotuning_3d.cpp
+++ b/src/sz_autotuning_3d.cpp
@@ -42,6 +42,7 @@ sz_compress_info sz_compress_decompress_3d(T *data, size_t num_elements, int r1,
         clock_gettime(CLOCK_REALTIME, &start);
         size_t lossless_output = sz_lossless_decompress(ZSTD_COMPRESSOR, result_after_lossless, lossless_outsize, &result,
                                                         result_size);
+        (void)lossless_output;
         T *dec_data = sz_decompress_3d_knl<T>(result, r1, r2, r3);
         clock_gettime(CLOCK_REALTIME, &end);
         compressInfo.decompress_time =
@@ -61,7 +62,7 @@ sz_compress_info sz_compress_decompress_3d(T *data, size_t num_elements, int r1,
 }
 
 template<typename T>
-unsigned char *do_compress(T *data, size_t num_elements, int r1, int r2, int r3, float precision,
+unsigned char *do_compress(T *data, size_t , int r1, int r2, int r3, float precision,
                            sz_params params, size_t &compressed_size) {
     size_t sz_result_size = 0;
     sz_compress_info compressInfo;
@@ -78,6 +79,7 @@ T *sz_decompress_autotuning_3d(unsigned char *compressed, size_t compress_size, 
 
     unsigned char *decompressed_lossless;
     size_t lossless_output = sz_lossless_decompress_v2(ZSTD_COMPRESSOR, compressed, compress_size, &decompressed_lossless);
+    (void)lossless_output;
     T *dec_data = sz_decompress_3d_knl<T>(decompressed_lossless, r1, r2, r3);
     free(decompressed_lossless);
     return dec_data;
@@ -85,7 +87,7 @@ T *sz_decompress_autotuning_3d(unsigned char *compressed, size_t compress_size, 
 
 
 template<typename T>
-sz_compress_info do_compress_sampling(const T *data, size_t num_elements, int r1, int r2, int r3, float precision,
+sz_compress_info do_compress_sampling(const T *data, size_t , int r1, int r2, int r3, float precision,
                                       sz_params params) {
     size_t result_size = 0;
     sz_compress_info compressInfo;
@@ -122,7 +124,7 @@ sz_compress_autotuning_3d(T *data, size_t r1, size_t r2, size_t r3, double relat
     size_t num_elements = r1 * r2 * r3;
     float max = data[0];
     float min = data[0];
-    for (int i = 1; i < num_elements; i++) {
+    for (size_t i = 1; i < num_elements; i++) {
         if (max < data[i]) max = data[i];
         if (min > data[i]) min = data[i];
     }
@@ -535,7 +537,7 @@ void sz_compress_manualtuning_3d(T *data, size_t num_elements, int r1, int r2, i
     sz_params best_params_stage1;
     for (auto use_lorenzo:{false, true}) {
         for (auto use_lorenzo_2layer:{false, true}) {
-            auto pred_dim_set = {3};
+          std::vector<int> pred_dim_set = {3};
             if (use_lorenzo || use_lorenzo_2layer) {
                 pred_dim_set = {1, 2, 3};
             }

--- a/src/sz_compress_3d.cpp
+++ b/src/sz_compress_3d.cpp
@@ -194,7 +194,7 @@ prediction_and_quantization_3d_with_knl_optimization(const T *data, const DSize_
                                                      int capacity, int intv_radius, unsigned char *indicator, int *type,
                                                      int *reg_params_type, float *&reg_unpredictable_data_pos,
                                                      int *unpred_count_buffer, T *unpred_data_buffer, size_t offset,
-                                                     const sz_params &params) {
+                                                     const sz_params &) {
     const float noise = precision * LorenzeNoise3d;
     int *type_pos = type;
     unsigned char *indicator_pos = indicator;
@@ -366,7 +366,7 @@ prediction_3d_sampling(const T *data, DSize_3d &size,
     }
 
 
-    size_t r1 = size.d1 - params.lorenzo_padding_layer;
+    //size_t r1 = size.d1 - params.lorenzo_padding_layer;
     size_t r2 = size.d2 - params.lorenzo_padding_layer;
     size_t r3 = size.d3 - params.lorenzo_padding_layer;
     const T *data_pos = data;// + layer * r2*r3 + layer * r3 + layer;

--- a/src/sz_decompress_3d.cpp
+++ b/src/sz_decompress_3d.cpp
@@ -12,7 +12,7 @@ template<typename T>
 void
 prediction_and_decompression_3d(const DSize_3d& size, const meanInfo<T>& mean_info, double precision,
 	int intv_radius, const float * reg_params, const unsigned char * indicator,
-	const int * type, const T * unpredictable_data_pos, T * dec_data, const sz_params& params){
+	const int * type, const T * unpredictable_data_pos, T * dec_data, const sz_params& ){
 	const int * type_pos = type;
 	const unsigned char * indicator_pos = indicator;
 	const float * reg_params_pos = reg_params;
@@ -55,7 +55,7 @@ template<typename T>
 void
 prediction_and_decompression_3d_with_border_prediction(const DSize_3d& size, const meanInfo<T>& mean_info, double precision,
 	int intv_radius, const float * reg_params, const unsigned char * indicator,
-	const int * type, const T * unpredictable_data_pos, T * dec_data, const sz_params& params){
+	const int * type, const T * unpredictable_data_pos, T * dec_data, const sz_params& ){
 	const int * type_pos = type;
 	const unsigned char * indicator_pos = indicator;
 	const float * reg_params_pos = reg_params;
@@ -101,7 +101,7 @@ template<typename T>
 void
 prediction_and_decompression_3d_with_knl_optimization(const DSize_3d& size, const meanInfo<T>& mean_info, T precision,
 	int intv_radius, const float * reg_params, const unsigned char * indicator,
-	const int * type, int * unpred_count_buffer, const T * unpred_data_buffer, const int offset, T * dec_data, const sz_params& params){
+	const int * type, int * unpred_count_buffer, const T * unpred_data_buffer, const int offset, T * dec_data, const sz_params&){
 	const int * type_pos = type;
 	const unsigned char * indicator_pos = indicator;
 	const float * reg_params_pos = reg_params;

--- a/src/sz_huffman.cpp
+++ b/src/sz_huffman.cpp
@@ -587,7 +587,7 @@ node reconstruct_HuffTree_from_bytes_anyStates(HuffmanTree *huffmanTree, const u
 		memset(C, 0, nodeCount*sizeof(unsigned int));
 		unsigned char* t = (unsigned char*)malloc(nodeCount*sizeof(unsigned char));
 		memset(t, 0, nodeCount*sizeof(unsigned char));
-		unsigned char cmpSysEndianType = bytes[0];
+		//unsigned char cmpSysEndianType = bytes[0];
 
 		memcpy(L, bytes+1, nodeCount*sizeof(unsigned char));
 		memcpy(R, bytes+1+nodeCount*sizeof(unsigned char), nodeCount*sizeof(unsigned char));
@@ -612,7 +612,7 @@ node reconstruct_HuffTree_from_bytes_anyStates(HuffmanTree *huffmanTree, const u
 		unsigned char* t = (unsigned char*)malloc(nodeCount*sizeof(unsigned char));
 		memset(t, 0, nodeCount*sizeof(unsigned char));	
 				
-		unsigned char cmpSysEndianType = bytes[0];	
+		//unsigned char cmpSysEndianType = bytes[0];	
 
 		memcpy(L, bytes+1, nodeCount*sizeof(unsigned short));
 		memcpy(R, bytes+1+nodeCount*sizeof(unsigned short), nodeCount*sizeof(unsigned short));
@@ -638,7 +638,7 @@ node reconstruct_HuffTree_from_bytes_anyStates(HuffmanTree *huffmanTree, const u
 		memset(C, 0, nodeCount*sizeof(unsigned int));
 		unsigned char* t = (unsigned char*)malloc(nodeCount*sizeof(unsigned char));
 		memset(t, 0, nodeCount*sizeof(unsigned char));
-		unsigned char cmpSysEndianType = bytes[0];
+		//unsigned char cmpSysEndianType = bytes[0];
 
 		memcpy(L, bytes+1, nodeCount*sizeof(unsigned int));
 		memcpy(R, bytes+1+nodeCount*sizeof(unsigned int), nodeCount*sizeof(unsigned int));

--- a/src/sz_lossless.cpp
+++ b/src/sz_lossless.cpp
@@ -69,7 +69,7 @@ unsigned long sz_lossless_decompress(int losslessCompressor, unsigned char* comp
 	return outSize;
 }
 
-unsigned long sz_lossless_decompress_v2(int losslessCompressor, unsigned char* compressBytes, unsigned long cmpSize, unsigned char** oriData)
+unsigned long sz_lossless_decompress_v2(int /*losslessCompressor*/, unsigned char* compressBytes, unsigned long cmpSize, unsigned char** oriData)
 {
 	unsigned long dataLength = 0;
 	const unsigned char *compressBytesPos = compressBytes;

--- a/src/sz_regression_utils.cpp
+++ b/src/sz_regression_utils.cpp
@@ -1,0 +1,29 @@
+#include "sz_def.hpp"
+#include "sz_regression_utils.hpp"
+#include <vector>
+#include <array>
+#include <algorithm>
+#include "sz_poly_regression_coeff_aux.hpp"
+
+std::vector<std::array<float, RegPolyCoeffNum3d * RegPolyCoeffNum3d>> init_poly() 
+{
+
+    const float *data = COEFF_3D;
+    size_t num = sizeof(COEFF_3D) / sizeof(float);;
+
+    auto coef_aux_p = &data[0];
+    std::vector<std::array<float, RegPolyCoeffNum3d * RegPolyCoeffNum3d>> coef_aux_list = std::vector<std::array<float,
+            RegPolyCoeffNum3d * RegPolyCoeffNum3d>>(
+            (COEF_AUX_MAX_BLOCK + 1) * (COEF_AUX_MAX_BLOCK + 1) * (COEF_AUX_MAX_BLOCK + 1), {0});
+    while (coef_aux_p < data + num) {
+        std::array<size_t, 3> dims = {0};
+        for (auto &idx:dims) {
+            idx = *coef_aux_p++;
+        }
+        std::copy_n(coef_aux_p, RegPolyCoeffNum3d * RegPolyCoeffNum3d,
+                    coef_aux_list[get_coef_aux_list_idx(dims)].begin());
+        coef_aux_p += RegPolyCoeffNum3d * RegPolyCoeffNum3d;
+    }
+//    display_coef_aux(coef_aux_list[get_coef_aux_list_idx( std::array<size_t, 3>{6, 6, 6})]);
+    return coef_aux_list;
+}


### PR DESCRIPTION
@disheng222 I fixed a number of issues in SZ auto that prohibited it from building with modern GCC and the CMake issue that caused the failure that you were seeing from spack.  Addditionally, the code attempted to free() an array stored in the BSS elf-segmant which caused a segfault on my system.  After that I was able to successfully use SZ auto from spack on my system.

```bash
pressio -i ~/git/datasets/hurricane/100x500x500/CLOUDf48.bin.f32 -t float -d 500 -d 500 -d 100 -m size SZauto -O all -o SZauto:error_bounds=1e-5 -m error_stat -M all
```

@ayzk Can you please take a look and see if all these changes seem correct?  Several of them were just compiler warnings, but some were more serious.